### PR TITLE
Allow multiple user agents

### DIFF
--- a/robots.h
+++ b/robots.h
@@ -112,7 +112,9 @@ class RobotsMatcher : protected RobotsParseHandler {
   static bool IsValidUserAgentToObey(absl::string_view user_agent);
 
   // Returns true iff 'url' is allowed to be fetched by any member of the
-  // "user_agents" vector. 'url' must be %-encoded according to RFC3986.
+  // "user_agents" vector after collapsing all rules applying to any member of 
+  // the "user_agents" vector into a single ruleset. 'url' must be %-encoded 
+  // according to RFC3986.
   bool AllowedByRobots(absl::string_view robots_body,
                        const std::vector<std::string>* user_agents,
                        const std::string& url);

--- a/robots_main.cc
+++ b/robots_main.cc
@@ -34,6 +34,7 @@
 //
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include "robots.h"
 
@@ -86,13 +87,18 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  std::string user_agent = argv[2];
-  std::vector<std::string> user_agents(1, user_agent);
+  std::string input_useragents = argv[2];
+  std::vector<std::string> useragents;
+  std::string ua;
+  std::istringstream ss(input_useragents);
+  while(std::getline(ss, ua, ',')) {
+      useragents.push_back(ua);
+  }
   googlebot::RobotsMatcher matcher;
   std::string url = argv[3];
-  bool allowed = matcher.AllowedByRobots(robots_content, &user_agents, url);
+  bool allowed = matcher.AllowedByRobots(robots_content, &useragents, url);
 
-  std::cout << "user-agent '" << user_agent << "' with URI '" << argv[3]
+  std::cout << "user-agent '" << input_useragents << "' with URI '" << argv[3]
             << "': " << (allowed ? "ALLOWED" : "DISALLOWED") << std::endl;
   if (robots_content.empty()) {
     std::cout << "notice: robots file is empty so all user-agents are allowed"

--- a/robots_test.cc
+++ b/robots_test.cc
@@ -33,6 +33,18 @@ bool IsUserAgentAllowed(const absl::string_view robotstxt,
   return matcher.OneAgentAllowedByRobots(robotstxt, useragent, url);
 }
 
+bool AllowedByRobots(const absl::string_view robotstxt,
+                        const std::string& input_useragents, const std::string& url) {
+  std::vector<std::string> useragents;
+  std::string ua;
+  std::istringstream ss(input_useragents);
+  while(std::getline(ss, ua, ',')) {
+      useragents.push_back(ua);
+  }
+  RobotsMatcher matcher;
+  return matcher.AllowedByRobots(robotstxt, &useragents, url);
+}
+
 // Google-specific: system test.
 TEST(RobotsUnittest, GoogleOnly_SystemTest) {
   const absl::string_view robotstxt =
@@ -121,6 +133,32 @@ TEST(RobotsUnittest, ID_LineSyntax_Groups) {
   EXPECT_FALSE(IsUserAgentAllowed(robotstxt, "FooBot", url_foo));
   EXPECT_FALSE(IsUserAgentAllowed(robotstxt, "BarBot", url_foo));
   EXPECT_FALSE(IsUserAgentAllowed(robotstxt, "BazBot", url_foo));
+}
+
+// Test based on the documentation at
+// https://developers.google.com/search/reference/robots_txt#order-of-precedence-for-user-agents
+// "Only one group is valid for a particular crawler"
+// "The group followed is group 1. Only the most specific group is followed, all others are ignored"
+TEST(RobotsUnittest, ID_Multiple_Useragents) {
+  const absl::string_view robotstxt =
+      "user-agent: googlebot-news\n"
+      "Disallow: /bar/\n"
+      "\n"
+      "user-agent: *\n"
+      "Disallow: /baz/\n"
+      "\n\n"
+      "user-agent: googlebot\n"
+      "Disallow: /foo/\n";
+
+  const std::string url_foo = "http://foo.bar/foo/";
+  const std::string url_bar = "http://foo.bar/bar/";
+  const std::string url_baz = "http://foo.bar/baz/";
+  const std::string url_qux = "http://foo.bar/qux/";
+
+  EXPECT_TRUE(AllowedByRobots(robotstxt, "googlebot,googlebot-news", url_foo)); // this currently fails
+  EXPECT_FALSE(AllowedByRobots(robotstxt, "googlebot,googlebot-news", url_bar));
+  EXPECT_TRUE(AllowedByRobots(robotstxt, "googlebot,googlebot-news", url_baz));
+  EXPECT_TRUE(AllowedByRobots(robotstxt, "googlebot,googlebot-news", url_qux));
 }
 
 // REP lines are case insensitive. See REP I-D section "Protocol Definition".


### PR DESCRIPTION
Take a comma-delimited list of user agents and pass them as a vector.