### PR TITLE
Ignore bazel build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 c-build/*
+bazel-*


### PR DESCRIPTION
One of the ways listed in the open source project for compiling and testing the project is using bazel - which creates directories that should be ignored by git as we never want to check them in